### PR TITLE
Remove `is_banned` from Artist and ArtistVersion

### DIFF
--- a/e621/models.py
+++ b/e621/models.py
@@ -267,7 +267,6 @@ class Artist(BaseModel):
     group_name: str
     linked_user_id: Optional[int]
     created_at: str
-    is_banned: bool
     creator_id: int
     is_locked: bool
     notes: Optional[str]


### PR DESCRIPTION
It seems that `is_banned: bool` in Artist and ArtistVersion is not a part of the returned JSON and is causing an exception to be raised and the data to be discarded. An example search that gave me this issue was `api.artists.search(any_name_matches="redrusker")`